### PR TITLE
Python 3.11 Support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.8, 3.9, '3.10']
+        python-version: [3.8, 3.9, '3.10', '3.11']
 
     steps:
     - uses: actions/checkout@v2

--- a/excmanager/Version.py
+++ b/excmanager/Version.py
@@ -1,4 +1,4 @@
 class Version(object):
     name="excmanager"
     description="RWTH Aachen Computer Science i5/dbis assets for Lecture Datenbanken und Informationssysteme"
-    version='0.2.9'
+    version='0.2.10'

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,8 @@ setup(
         'Programming Language :: Python',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
-        'Programming Language :: Python :: 3.10'
+        'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11'
     ],
     packages=["excmanager"],
     include_package_data=True,


### PR DESCRIPTION
Officially support python 3.11. Changes:
 - Add python 3.11 classifier to `setup.py`.
 - Add python 3.11 to github build workflow (testing - [passed](https://github.com/CodingTil/dbis-exercise-manager/actions/runs/3575206898)).
 - Patch-Version bump. _No changes to the codebase of the package were necessary_

Why Python 3.11 support?
 - Python 3.11 is the latest major release of python.
 - Offers great performance improvements.
 - I want to use this package in python 3.11.