### PR TITLE
Improved type hinting and changed  levenshtein_for_lists

### DIFF
--- a/tests/test_Util.py
+++ b/tests/test_Util.py
@@ -6,6 +6,7 @@ from Levenshtein import seqratio, setratio
 from tests.basetest import Basetest
 from excmanager.Util import Util
 
+
 class TestUtil(Basetest):
     """
     test the Util module
@@ -52,10 +53,10 @@ class TestUtil(Basetest):
                         ["Blade Runner", "Matrix", "Sci-Fi"]],
                     attributes_student=["A.Titel", "B.Titel", "A.Genre"],
                     tuples_student=[
-                        ["Pulp Fiction","Cloud Atlas","Independant"],
-                        ["Cloud Atlas","Pulp Fiction","Independant"],
-                        ["Alien","Matrix","Sci-Fi"],
-                        ["Blade Runner","Matrix","Sci-Fi"]],
+                        ["Pulp Fiction", "Cloud Atlas", "Independant"],
+                        ["Cloud Atlas", "Pulp Fiction", "Independant"],
+                        ["Alien", "Matrix", "Sci-Fi"],
+                        ["Blade Runner", "Matrix", "Sci-Fi"]],
                     levenshtein_threshold=0.8,
                     expected_result=True),
             TestParam(
@@ -84,9 +85,17 @@ class TestUtil(Basetest):
             ),
             TestParam(
                     attributes_solution=["Vorname", "Nachname"],
-                    tuples_solution=[["Quentin","Tarantino"], ["Robert", "Rodriguez"], ["Ridley", "Scott"], ["Lana", "Wachowski"]],
+                    tuples_solution=[
+                        ["Quentin", "Tarantino"],
+                        ["Robert", "Rodriguez"],
+                        ["Ridley", "Scott"],
+                        ["Lana", "Wachowski"]],
                     attributes_student=["Vornname", "Nachname"],
-                    tuples_student=[["Quendin","Tarantino"], ["Robert", "Rodriguez"], ["Ridley", "Scott"], ["Lana", "Wachowski"]],
+                    tuples_student=[
+                        ["Quendin", "Tarantino"],
+                        ["Robert", "Rodriguez"],
+                        ["Ridley", "Scott"],
+                        ["Lana", "Wachowski"]],
                     levenshtein_threshold=0.8,
                     expected_result=True
             )
@@ -102,7 +111,6 @@ class TestUtil(Basetest):
                         quiet=param.quiet
                 )
                 self.assertEqual(res, param.expected_result)
-
 
     def test_levenshtein_for_lists(self):
         """

--- a/tests/test_Util.py
+++ b/tests/test_Util.py
@@ -1,3 +1,7 @@
+from dataclasses import dataclass
+from typing import Any, List
+
+from Levenshtein import seqratio, setratio
 
 from tests.basetest import Basetest
 from excmanager.Util import Util
@@ -13,64 +17,126 @@ class TestUtil(Basetest):
         """
         test checking tables
         """
-        assert Util.check_table(["A"], [[]], ["A"], [[]], 0.5, True) == True
+        @dataclass
+        class TestParam:
+            attributes_solution: List[str]
+            tuples_solution: List[Any]
+            attributes_student: List[str]
+            tuples_student: List[Any]
+            levenshtein_threshold: float = 1
+            quiet: bool = False
+            expected_result: bool = True
+        test_params = [
+            TestParam(["A"], [[]], ["A"], [[]], 0.5, expected_result=True),
+            TestParam(["A"], [[]], ["B"], [[]], 0.5, expected_result=False),
+            TestParam(
+                    attributes_solution=["A.Titel", "B.Titel", "A.Genre"],
+                    tuples_solution=[
+                        ["Pulp Fiction", "Cloud Atlas", "Independent"],
+                        ["Cloud Atlas", "Pulp Fiction", "Independent"],
+                        ["Blade Runner", "Matrix", "Sci-Fi"]],
+                    attributes_student=["A.Titel", "B.Titel", "A.Genre"],
+                    tuples_student=[
+                        ["Alien", "Matrix", "Sci-Fi"],
+                        ["Pulp Fiction", "Cloud Atlas", "Independant"],
+                        ["Cloud Atlas", "Pulp Fiction", "Independant"],
+                        ["Blade Runner", "Matrix", "Sci-Fi"]],
+                    levenshtein_threshold=1,
+                    expected_result=False
+            ), TestParam(
+                    attributes_solution=["A.Titel", "B.Titel", "A.Genre"],
+                    tuples_solution=[
+                        ["Alien", "Matrix", "Sci-Fi"],
+                        ["Pulp Fiction", "Cloud Atlas", "Independent"],
+                        ["Cloud Atlas", "Pulp Fiction", "Independent"],
+                        ["Blade Runner", "Matrix", "Sci-Fi"]],
+                    attributes_student=["A.Titel", "B.Titel", "A.Genre"],
+                    tuples_student=[
+                        ["Pulp Fiction","Cloud Atlas","Independant"],
+                        ["Cloud Atlas","Pulp Fiction","Independant"],
+                        ["Alien","Matrix","Sci-Fi"],
+                        ["Blade Runner","Matrix","Sci-Fi"]],
+                    levenshtein_threshold=0.8,
+                    expected_result=True),
+            TestParam(
+                    attributes_solution=["Nationalität"],
+                    tuples_solution=[["FRANZÖSISCH"], ["ÖSTERREICHISCH"]],
+                    attributes_student=["  nationalitaet     "],
+                    tuples_student=[["oesterreichisch"], ["     fransoesischh  "]],
+                    levenshtein_threshold=0.8,
+                    expected_result=True
+            ),
+            # Complete test of:
+            # * umlauts
+            # * spelling errors
+            # * permutation of attributes
+            # * permutation of tuples
+            # * whitespace
+            # * ints instead of strings
+            # * tuples instead of lists
+            TestParam(
+                    attributes_solution=["Nationalität", "Alter"],
+                    tuples_solution=[["FRANZÖSISCH", "2"], ["ÖSTERREICHISCH", "1"]],
+                    attributes_student=["alterr", "  nationalitaet     "],
+                    tuples_student=[(1, "oesterreichisch"), (2, "     fransoesischh  ")],
+                    levenshtein_threshold=0.8,
+                    expected_result=True
+            ),
+            TestParam(
+                    attributes_solution=["Vorname", "Nachname"],
+                    tuples_solution=[["Quentin","Tarantino"], ["Robert", "Rodriguez"], ["Ridley", "Scott"], ["Lana", "Wachowski"]],
+                    attributes_student=["Vornname", "Nachname"],
+                    tuples_student=[["Quendin","Tarantino"], ["Robert", "Rodriguez"], ["Ridley", "Scott"], ["Lana", "Wachowski"]],
+                    levenshtein_threshold=0.8,
+                    expected_result=True
+            )
+        ]
+        for param in test_params:
+            with self.subTest(param=param):
+                res = Util.check_table(
+                        attributes_solution=param.attributes_solution,
+                        tuples_solution=param.tuples_solution,
+                        attributes_student=param.attributes_student,
+                        tuples_student=param.tuples_student,
+                        levenshtein_threshold=param.levenshtein_threshold,
+                        quiet=param.quiet
+                )
+                self.assertEqual(res, param.expected_result)
 
-        assert Util.check_table(["A"], [[]], ["B"], [[]], 0.5, True) == False
 
-        assert Util.check_table(
-            ["A.Titel","B.Titel","A.Genre"],
-            [["Pulp Fiction","Cloud Atlas","Independent"],
-            ["Cloud Atlas","Pulp Fiction","Independent"],
-            ["Alien","Matrix","Sci-Fi"],
-            ["Blade Runner","Matrix","Sci-Fi"]],
-            
-            ["A.Titel","B.Titel","A.Genre"],
-            [["Alien","Matrix","Sci-Fi"],
-            ["Pulp Fiction","Cloud Atlas","Independant"],
-            ["Cloud Atlas","Pulp Fiction","Independant"],
-            ["Blade Runner","Matrix","Sci-Fi"]], 1, True) == False
+    def test_levenshtein_for_lists(self):
+        """
+        test levenshtein_list_callback
+        """
+        test_params = [
+            (['pulp fiction', 'cloud atlas', 'independant'], ['pulp fiction', 'cloud atlas', 'independent']),
+            (['independant', 'cloud atlas', 'pulp fiction'], ['pulp fiction', 'independent', 'cloud atlas']),
+            (['pulp fiction', 'independant', 'cloud atlas'], ['pulp fiction', 'cloud atlas', 'independent']),
+            (['independant', 'pulp fiction',  'cloud atlas'], ['pulp fiction', 'cloud atlas', 'independent']),
+            (['independant', 'pulp fiction',  'cloud atlas'], ['pulp fiction', 'cloud atlas', 'independence day']),
+            (['pulp fiction',  'cloud atlas'], ['pulp fiction', 'cloud atlas', 'independent']),
+        ]
+        for param in test_params:
+            a, b = param
+            seq_ratio = seqratio(a, b)
+            set_ratio = setratio(a, b)
+            print(f"seqratio:{seq_ratio} setratio: {set_ratio} for a={a} and b={b}")
 
-        assert Util.check_table(
-            ["A.Titel","B.Titel","A.Genre"],
-            [["Alien","Matrix","Sci-Fi"],
-            ["Pulp Fiction","Cloud Atlas","Independent"],
-            ["Cloud Atlas","Pulp Fiction","Independent"],
-            ["Blade Runner","Matrix","Sci-Fi"]],
-            
-            ["A.Titel","B.Titel","A.Genre"],
-            [["Pulp Fiction","Cloud Atlas","Independant"],
-            ["Cloud Atlas","Pulp Fiction","Independant"],
-            ["Alien","Matrix","Sci-Fi"],
-            ["Blade Runner","Matrix","Sci-Fi"]], 0.8, True) == True
-
-        assert Util.check_table(
-            ["Nationalität"],
-            [["FRANZÖSISCH"], ["ÖSTERREICHISCH"]],
-            ["  nationalitaet     "],
-            [["oesterreichisch"], ["     fransoesischh  "]], 0.8, True) == True
-
-        # Complete test of:
-        # * umlauts
-        # * spelling errors
-        # * permutation of attributes
-        # * permutation of tuples
-        # * whitespace
-        # * ints instead of strings
-        # * tuples instead of lists
-        assert Util.check_table(
-            ["Nationalität", "Alter"],
-            [["FRANZÖSISCH", "2"], ["ÖSTERREICHISCH", "1"]],
-
-            ["alterr", "  nationalitaet     "],
-            [(1, "oesterreichisch"), (2, "     fransoesischh  ")],
-            
-            0.8, True) == True
-
-        assert Util.check_table(
-            ["Vorname", "Nachname"],
-            [["Quentin","Tarantino"], ["Robert", "Rodriguez"], ["Ridley", "Scott"], ["Lana", "Wachowski"]],
-            ["Vornname", "Nachname"],
-            [["Quendin","Tarantino"], ["Robert", "Rodriguez"], ["Ridley", "Scott"], ["Lana", "Wachowski"]],
-            0.8,
-            False
-        ) == True
+    def test_levenshtein_list_callback(self):
+        """
+        test levenshtein_list_callback
+        """
+        test_params = [
+            (['pulp fiction', 'cloud atlas', 'independant'], ['pulp fiction', 'cloud atlas', 'independent'], 0.9696969696969697),
+            (['independant', 'cloud atlas', 'pulp fiction'], ['pulp fiction', 'independent', 'cloud atlas'], 0.9696969696969697),
+            (['pulp fiction', 'independant', 'cloud atlas'], ['pulp fiction', 'cloud atlas', 'independent'], 0.9696969696969697),
+            (['independant', 'pulp fiction',  'cloud atlas'], ['pulp fiction', 'cloud atlas', 'independent'], 0.9696969696969697),
+            (['independant', 'pulp fiction',  'cloud atlas'], ['pulp fiction', 'cloud atlas', 'independence day'], 0.8888888888888888),
+            (['pulp fiction',  'cloud atlas'], ['pulp fiction', 'cloud atlas', 'independent'], 0.8),
+            (["tenet"], ["tenet"], 1.0)
+        ]
+        for param in test_params:
+            with self.subTest(param=param):
+                a, b, expected_ratio = param
+                sr = Util.levenshtein_list_callback(a, b)
+                self.assertEqual(expected_ratio, sr)


### PR DESCRIPTION
Changed levenshtein_for_lists by exchanging seqratio with setratio. There is also a test case comparing both methods. The result of the test is shown below. Both methods do not check for the order of the list items and the seqratio gets low ratios even if only one char is incorrect.
> There was an issue in the result normalization see https://github.com/maxbachmann/python-Levenshtein/releases/tag/v0.20.6 that was fixed that could have lead to the issue when updating the versions
```bash
seqratio:0.7246376811594203 setratio: 0.9696969696969697 for a=['pulp fiction', 'cloud atlas', 'independant'] and b=['pulp fiction', 'cloud atlas', 'independent']
seqratio:0.6363636363636364 setratio: 0.9696969696969697 for a=['independant', 'cloud atlas', 'pulp fiction'] and b=['pulp fiction', 'independent', 'cloud atlas']
seqratio:0.7233201581027667 setratio: 0.9696969696969697 for a=['pulp fiction', 'independant', 'cloud atlas'] and b=['pulp fiction', 'cloud atlas', 'independent']
seqratio:0.6666666666666666 setratio: 0.9696969696969697 for a=['independant', 'pulp fiction', 'cloud atlas'] and b=['pulp fiction', 'cloud atlas', 'independent']
seqratio:0.6666666666666666 setratio: 0.8888888888888888 for a=['independant', 'pulp fiction', 'cloud atlas'] and b=['pulp fiction', 'cloud atlas', 'independence day']
seqratio:0.8 setratio: 0.8 for a=['pulp fiction', 'cloud atlas'] and b=['pulp fiction', 'cloud atlas', 'independent']
```